### PR TITLE
optimize papi setup, remove bin conf

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env npx tsx
-
 import * as fs from "node:fs/promises";
 import type { PushEvent } from "@octokit/webhooks-types";
 import { ksm } from "@polkadot-api/descriptors";

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,6 @@
         "@polkadot/util-crypto": "^13.5.2",
         "polkadot-api": "^1.14.0"
       },
-      "bin": {
-        "publish-commit": "index.ts"
-      },
       "devDependencies": {
         "@biomejs/biome": "^1.9.3",
         "@tsconfig/node20": "^20.1.6",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "author": "Fluffy Labs",
   "type": "commonjs",
   "main": "index.ts",
-  "bin": "index.ts",
   "scripts": {
     "qa": "biome ci",
     "qa-fix": "npm run format; npm run lint",
@@ -26,7 +25,7 @@
     "lint": "biome lint --write; biome check --write",
     "start": "tsx index.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "papi add ksm -n ksmcc3_asset_hub && papi"
+    "postinstall": "papi"
   },
   "dependencies": {
     "@octokit/webhooks-types": "^7.6.1",


### PR DESCRIPTION
Removed an unnecessary step from papi postinstall.
Removed bin/executable configuration because this package won't work using npx. The papi postinstall script causes difficult to diagnose errors.